### PR TITLE
Engineering hygiene: packaging, tests, linting, CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install project and dev dependencies
+        run: python -m pip install --upgrade pip && pip install -e ".[dev]"
+
+      - name: Lint (ruff)
+        run: ruff check .
+
+      - name: Run tests
+        run: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,13 @@ test
 tempCodeRunnerFile.py
 .vscode
 .conda
+
+# Python build / tooling artifacts
+*.egg-info/
+build/
+dist/
+.pytest_cache/
+.ruff_cache/
+
+# macOS
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -163,3 +163,30 @@ Explanation of the metadata file columns:
 
 - **TSV file**: Intensity data from FragPipe.
 - **CSV file**: Metadata (formatted as described above)
+
+---
+
+## **Development**
+
+Dependencies are declared in `pyproject.toml` (the canonical source; `requirements.txt`
+mirrors the core runtime deps for the Docker build).
+
+```bash
+# Create an environment and install the app plus dev tools (tests + linter)
+python -m pip install -e ".[dev]"
+
+# Run the app locally
+streamlit run tpp_solver_mt.py
+
+# Lint and run the test suite
+ruff check .
+pytest
+```
+
+Optional extras:
+
+- `pip install ".[scraper]"` — installs `biopython`/`requests` needed only to
+  (re)build the GO/proteome database with `scraper.py`.
+
+Continuous integration (`.github/workflows/ci.yml`) runs `ruff` and `pytest`
+against Python 3.10–3.12 on every push and pull request.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,55 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "tpp-solver"
+version = "1.2.0"
+description = "Streamlit app for analyzing protein thermal stability via Thermal Proteome Profiling (TPP)."
+readme = "README.md"
+requires-python = ">=3.10"
+license = { file = "LICENSE" }
+# Core runtime dependencies for the Streamlit app. Pinned to compatible ranges
+# for reproducible builds; this table is the single source of truth (the legacy
+# requirements.txt mirrors it).
+dependencies = [
+    "streamlit>=1.40,<2",
+    "pandas>=2.2,<3",
+    "numpy>=2.1,<3",
+    "matplotlib>=3.9,<4",
+    "scipy>=1.14,<2",
+    "plotly>=5.24,<6",
+    "duckdb>=1.1,<2",
+]
+
+[project.optional-dependencies]
+# Only needed to (re)build the GO/proteome database with scraper.py.
+scraper = [
+    "biopython>=1.84,<2",
+    "requests>=2.32,<3",
+]
+# Tooling for tests and linting.
+dev = [
+    "pytest>=8,<10",
+    "ruff>=0.6",
+]
+
+[tool.setuptools]
+# Flat single-module layout (no package directory); list the modules explicitly
+# so setuptools does not try to auto-discover data directories (fasta/, assets/).
+py-modules = ["tpp_solver_mt", "scraper", "readme_content"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+# Import the top-level modules without installing the project.
+pythonpath = ["."]
+addopts = "-q"
+
+[tool.ruff]
+target-version = "py310"
+line-length = 100
+
+[tool.ruff.lint]
+# Pragmatic ruleset: real-bug checks (pyflakes + a subset of pycodestyle) plus
+# flake8-bugbear. Full style/formatting is enforced on the refactored package.
+select = ["E4", "E7", "E9", "F", "B"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,11 @@
-streamlit
-pandas
-numpy
-matplotlib
-seaborn
-scikit-learn
-biopython
-duckdb
-scipy
-requests
-plotly
-seaborn
+# Core runtime dependencies for the TPP Solver Streamlit app.
+# Kept in sync with [project.dependencies] in pyproject.toml (the canonical source).
+# Scraper-only deps (biopython, requests) live in the "scraper" optional-dependencies
+# group; install with:  pip install ".[scraper]"
+streamlit>=1.40,<2
+pandas>=2.2,<3
+numpy>=2.1,<3
+matplotlib>=3.9,<4
+scipy>=1.14,<2
+plotly>=5.24,<6
+duckdb>=1.1,<2

--- a/tests/test_data_processing.py
+++ b/tests/test_data_processing.py
@@ -1,0 +1,73 @@
+"""Tests for the pure data-processing helpers in tpp_solver_mt."""
+import numpy as np
+import pandas as pd
+import pytest
+
+import tpp_solver_mt as m
+
+
+def test_impute_is_deterministic_with_seed_and_fills_zeros():
+    df = pd.DataFrame({"s1": [10.0, 0.0, 5.0], "s2": [0.0, 3.0, 0.0]})
+    samples = ["s1", "s2"]
+
+    out1 = m.impute_filtered_data(df.copy(), samples, lowest_float=1.0, seed=123)
+    out2 = m.impute_filtered_data(df.copy(), samples, lowest_float=1.0, seed=123)
+
+    # Same seed -> identical imputation (reproducible results).
+    pd.testing.assert_frame_equal(out1[samples], out2[samples])
+
+    # No zeros remain and imputed values fall in (0, lowest_float).
+    assert (out1[samples].to_numpy() > 0).all()
+    assert 0 < out1.loc[1, "s1"] < 1.0
+    # Original non-zero values are preserved.
+    assert out1.loc[0, "s1"] == 10.0
+
+
+def test_impute_different_seeds_differ():
+    df = pd.DataFrame({"s1": [0.0, 0.0, 0.0]})
+    a = m.impute_filtered_data(df.copy(), ["s1"], 1.0, seed=1)
+    b = m.impute_filtered_data(df.copy(), ["s1"], 1.0, seed=2)
+    assert not np.allclose(a["s1"].to_numpy(), b["s1"].to_numpy())
+
+
+def test_process_summary_tables_aggregates_replicates():
+    summary = pd.DataFrame(
+        {
+            "protein": ["P1", "P1", "P2", "P2"],
+            "treatment": ["c", "c", "c", "c"],
+            "melting_point": [50.0, 52.0, 60.0, 60.0],
+            "R²": [0.90, 0.95, 0.80, 0.82],
+            "residuals": ["0,0", "0,0", "0,0", "0,0"],
+        }
+    )
+    replicate_table, averaged_table = m.process_summary_tables(summary)
+
+    assert len(replicate_table) == 4  # replicate table keeps every row
+    p1 = averaged_table[averaged_table["protein"] == "P1"].iloc[0]
+    assert p1["melting_point"] == pytest.approx(51.0)
+    assert p1["num_replicates"] == 2
+    assert p1["melting_point_std"] == pytest.approx(np.std([50.0, 52.0], ddof=1))
+
+    p2 = averaged_table[averaged_table["protein"] == "P2"].iloc[0]
+    assert p2["melting_point_std"] == pytest.approx(0.0)  # identical replicates
+
+
+def test_get_replicate_data_builds_nested_structure():
+    csv_data = pd.DataFrame(
+        {
+            "Treatment": ["c", "c", "d", "d"],
+            "Temperature": [37, 50, 37, 50],
+            "Samples": ["s1", "s2", "s3", "s4"],
+        }
+    )
+    filtered = pd.DataFrame(
+        {"Protein ID": ["P1"], "s1": [10.0], "s2": [5.0], "s3": [8.0], "s4": [4.0]}
+    )
+
+    rd = m.get_replicate_data(csv_data, filtered)
+
+    assert set(rd.keys()) == {"c", "d"}
+    assert rd["c"]["P1"][37.0] == [10.0]
+    assert rd["c"]["P1"][50.0] == [5.0]
+    assert rd["d"]["P1"][37.0] == [8.0]
+    assert rd["d"]["P1"][50.0] == [4.0]

--- a/tests/test_fitting.py
+++ b/tests/test_fitting.py
@@ -1,0 +1,71 @@
+"""Tests for the curve-fitting model functions and the worker data slicer."""
+import numpy as np
+import pytest
+
+import tpp_solver_mt as m
+
+
+def test_sigmoid_midpoint_and_monotonicity():
+    a, b, plateau = 1.0, 50.0, 0.0
+    # At T == b the logistic term is exactly a/2.
+    assert m.sigmoid(b, a, b, plateau) == pytest.approx(a / 2 + plateau)
+    temps = np.linspace(30, 70, 50)
+    vals = m.sigmoid(temps, a, b, plateau)
+    assert np.all(np.diff(vals) > 0)  # strictly increasing for a > 0
+
+
+def test_paper_sigmoidal_midpoint_is_mean_of_plateaus():
+    A1, A2, Tm = 1.0, 0.0, 55.0
+    assert m.paper_sigmoidal(Tm, A1, A2, Tm) == pytest.approx((A1 + A2) / 2)
+
+
+def test_slice_replicate_data_returns_only_one_protein():
+    replicate_data = {
+        "control": {"P1": {37.0: [1.0]}, "P2": {37.0: [2.0]}},
+        "drug": {"P1": {37.0: [3.0]}},
+    }
+    sliced = m._slice_replicate_data(replicate_data, "P1")
+    assert set(sliced.keys()) == {"control", "drug"}
+    assert list(sliced["control"].keys()) == ["P1"]
+    assert "P2" not in sliced["control"]
+    assert sliced["drug"]["P1"] == {37.0: [3.0]}
+
+
+def test_slice_replicate_data_skips_treatments_without_protein():
+    replicate_data = {
+        "control": {"P1": {37.0: [1.0]}},
+        "drug": {"P2": {37.0: [2.0]}},  # no P1 here
+    }
+    sliced = m._slice_replicate_data(replicate_data, "P1")
+    assert "drug" not in sliced
+    assert list(sliced.keys()) == ["control"]
+
+
+def test_process_protein_replicates_recovers_melting_point():
+    """Worker runs without Streamlit and with the explicit-args signature."""
+    import matplotlib.pyplot as plt
+
+    temps = [37, 40, 45, 50, 55, 60, 65]
+    tm = 52.0
+    protein_data = {t: [1.0 / (1.0 + np.exp(t - tm))] for t in temps}  # one replicate
+    data_dict = {"control": {"P1": protein_data}}
+
+    args = (
+        "P1",
+        data_dict,
+        ["o", "s", "^", "v"],   # marker_opts
+        [50, 75, 100],          # size_opts
+        [1.0, 0.8, 0.6],        # alpha_opts
+        None,                   # selected_temp
+        False,                  # normalize_data
+        0.8,                    # r2_threshold
+        "Reference Temperature",
+        (0.05, 0.05),           # winsor_limits
+    )
+    protein, fig, summary = m.process_protein_replicates(args)
+
+    assert protein == "P1"
+    assert len(summary) == 1
+    assert summary[0]["treatment"] == "control"
+    assert summary[0]["melting_point"] == pytest.approx(tm, abs=1.0)
+    plt.close("all")

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -1,0 +1,59 @@
+"""Tests for the pure normalization helpers in tpp_solver_mt."""
+import numpy as np
+import pytest
+
+import tpp_solver_mt as m
+
+
+def test_median_basic_and_zero_preservation():
+    values = np.array([0.0, 1.0, 2.0, 4.0])
+    out = m.normalize_by_median(values)
+    # positive median is 2.0 -> nonzero values divided by 2, zeros preserved
+    np.testing.assert_allclose(out, [0.0, 0.5, 1.0, 2.0])
+
+
+def test_median_all_zero_returns_unchanged():
+    values = np.zeros(5)
+    np.testing.assert_array_equal(m.normalize_by_median(values), values)
+
+
+def test_robust_zscore_centers_on_median():
+    values = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+    out = m.normalize_by_robust_zscore(values)
+    # median is 3 -> the middle element maps to 0 and the result is symmetric
+    assert out[2] == pytest.approx(0.0)
+    np.testing.assert_allclose(out, -out[::-1], atol=1e-12)
+
+
+def test_robust_zscore_constant_input_is_safe():
+    values = np.full(4, 7.0)  # MAD == 0 -> function must not divide by zero
+    np.testing.assert_array_equal(m.normalize_by_robust_zscore(values), values)
+
+
+def test_winsorization_caps_extremes_and_preserves_zeros():
+    values = np.array([0.0, 1.0, 2.0, 3.0, 4.0, 100.0])
+    out = m.normalize_by_winsorization(values, limits=(0.2, 0.2))
+    assert out[0] == 0.0                 # zero preserved
+    assert out.max() < 100.0             # extreme value pulled in
+    assert len(out) == len(values)
+
+
+def test_quantile_preserves_length_and_zeros():
+    values = np.array([0.0, 5.0, 3.0, 9.0, 1.0])
+    out = m.normalize_by_quantile(values)
+    assert out[0] == 0.0
+    assert len(out) == len(values)
+
+
+@pytest.mark.parametrize(
+    "fn",
+    [
+        m.normalize_by_median,
+        m.normalize_by_robust_zscore,
+        m.normalize_by_quantile,
+        m.normalize_by_winsorization,
+    ],
+)
+def test_empty_input_returns_empty(fn):
+    out = fn(np.array([]))
+    assert len(out) == 0

--- a/tpp_solver_mt.py
+++ b/tpp_solver_mt.py
@@ -217,8 +217,6 @@ def filter_and_lowest_float(tsv_data, samples):
     if missing_cols:
         raise ValueError("The TSV file does not contain all values from 'Samples' in the CSV")
     
-    selected_data = tsv_data[samples]
-    num_data = selected_data.apply(pd.to_numeric, errors='coerce')
     filtered_data = tsv_data  # No filtering based on zeros anymore
 
     num_filtered_data = filtered_data[samples].apply(pd.to_numeric, errors='coerce')
@@ -320,7 +318,6 @@ def process_protein_replicates(args):
         marker_opts,
         size_opts,
         alpha_opts,
-        position_opts,
         selected_temp,
         normalize_data,
         r2_threshold,
@@ -333,14 +330,12 @@ def process_protein_replicates(args):
     markers = itertools.cycle(marker_opts)
     sizes = itertools.cycle(size_opts)
     alphas = itertools.cycle(alpha_opts)
-    positions = itertools.cycle(position_opts)
 
     summary_data = []
     fig = None
     ax = None
-    
+
     try:
-        y_offset = 0.0
         for treatment, proteins in data_dict.items():
             if protein in proteins:
                 protein_data = proteins[protein]
@@ -427,8 +422,7 @@ def process_protein_replicates(args):
                     marker = next(markers)
                     size = next(sizes)
                     alpha = next(alphas)
-                    curpos = next(positions)
-                    
+
                     # Plot each replicate
                     for i, fit_data in enumerate(replicate_fits):
                         # Plot measured points
@@ -586,7 +580,6 @@ def fit_and_plot_replicates(replicate_data, selected_temp, normalize_data, r2_th
     marker_opts = ['o', 's', '^', 'v']
     size_opts = [50, 75, 100]
     alpha_opts = [1.0, 0.8, 0.6]
-    position_opts = ['left', 'right']
 
     # Resolve normalization settings on the main thread. Worker processes have no
     # Streamlit session context (the default start method is 'spawn' on macOS and
@@ -608,7 +601,6 @@ def fit_and_plot_replicates(replicate_data, selected_temp, normalize_data, r2_th
             marker_opts,
             size_opts,
             alpha_opts,
-            position_opts,
             selected_temp,
             normalize_data,
             r2_threshold,
@@ -846,7 +838,7 @@ def compare_melting_points_violin(averaged_table):
     # Assign colors to treatments
     treatments = data['treatment'].unique()
     colors = px.colors.qualitative.Plotly
-    color_map = dict(zip(treatments, colors))
+    color_map = dict(zip(treatments, colors, strict=False))
     treatment_to_num = {treatment: idx for idx, treatment in enumerate(treatments)}
 
     # Create violin plots
@@ -1953,7 +1945,7 @@ def fit_and_plot_averaged_curves(replicate_data, selected_temp=None, normalize_d
     summary_data = []
     all_proteins = set()
     
-    for treatment, proteins_dict in replicate_data.items():
+    for proteins_dict in replicate_data.values():
         for prot in proteins_dict.keys():
             all_proteins.add(prot)
 
@@ -2168,8 +2160,9 @@ def analysis():
                 st.error("Failed to extract samples from metadata. Please check your CSV file.")
                 return
                 
-            normalize_data = setup_analysis_parameters(metadata)
-            
+            # Records the normalization choice in st.session_state for later use.
+            setup_analysis_parameters(metadata)
+
             # Setup GO annotation
             include_go_annotation, selected_species = setup_go_annotation()
             


### PR DESCRIPTION
Second of four stacked PRs from the project review. **Base branch is `fix/critical-scalability` (PR #10)** so the diff shows only this PR's changes — merge #10 first.

Purely additive engineering hygiene; no app behavior changes beyond linter-driven dead-code removal.

## Packaging & dependencies
- **`pyproject.toml`** is now the canonical project file: pinned dependency ranges, a `scraper` extra (`biopython`/`requests`, needed only by `scraper.py`) and a `dev` extra (`pytest`/`ruff`). Installable via `pip install -e ".[dev]"`.
- **`requirements.txt`** trimmed to the core runtime deps and kept in sync with `pyproject`. Removed the **duplicated `seaborn`** line and the **unused `seaborn` and `scikit-learn`** packages (neither is imported anywhere).

## Tests (19, all passing)
`tests/` covers the pure logic that can be tested without a Streamlit runtime:
- the four normalizers (incl. zero-preservation and divide-by-zero safety),
- the `sigmoid` / `paper_sigmoidal` models,
- `_slice_replicate_data`, and the multiprocessing **worker** called directly (guards the new explicit-args signature),
- imputation determinism (same seed → identical output),
- `get_replicate_data` structure and `process_summary_tables` aggregation (mean/std/replicate counts).

## Linting & CI
- **ruff** configured (`E4/E7/E9/F/B`) — real-bug + bugbear checks the current code passes.
- **`.github/workflows/ci.yml`** runs `ruff` + `pytest` on Python 3.10/3.11/3.12 for every push and PR.
- Removed dead assignments the linter flagged (`num_data`, `y_offset`, the unused `curpos`/`positions` plumbing, an unused `normalize_data` return) and made `zip()` strict-explicit.

## Docs
- README **Development** section (install, run, lint, test).
- `.gitignore` entries for build/test artifacts (`*.egg-info/`, `.pytest_cache/`, `.ruff_cache/`, `.DS_Store`).

> Note for a follow-up: the Winsorization default limits `(0.05, 0.95)` are passed straight to `scipy.stats.mstats.winsorize`, which interprets them as *cut fractions* per tail — `(0.05, 0.95)` cuts 95% off the top. This looks like a latent scientific bug (likely meant `(0.05, 0.05)`); flagged here, left for a dedicated fix.
