### PR TITLE
Add Makefile for easy run/dev tasks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,61 @@
-server-compose-build-nocache:
-	docker-compose --compatibility build --no-cache
+# TPP Solver -- common developer tasks. Run `make` or `make help` for the list.
 
-server-compose-interactive:
-	docker-compose --compatibility build
-	docker-compose --compatibility -f docker-compose.yml -f docker-compose-dev.yml up
+PYTHON  ?= python
+COMPOSE ?= docker compose
+PORT    ?= 8501
+APP     := tpp_solver_mt.py
 
-server-compose:
-	docker-compose --compatibility build
-	docker-compose --compatibility -f docker-compose.yml -f docker-compose-dev.yml up -d
+.DEFAULT_GOAL := help
 
-server-compose-production:
-	docker-compose --compatibility build
-	docker-compose --compatibility -f docker-compose.yml up -d
+.PHONY: help install run test lint format docker-build docker-run \
+        server-compose-build-nocache server-compose-interactive \
+        server-compose server-compose-production attach
 
-attach:
-	docker exec -i -t template-streamlit /bin/bash
+help: ## Show this help
+	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
+		| awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+# --- Local development -------------------------------------------------------
+
+install: ## Install the app + dev tools (pytest, ruff) in editable mode
+	$(PYTHON) -m pip install -e ".[dev]"
+
+run: ## Run the Streamlit app locally (override with PORT=...)
+	$(PYTHON) -m streamlit run $(APP) --server.port $(PORT)
+
+test: ## Run the test suite
+	$(PYTHON) -m pytest
+
+lint: ## Lint with ruff
+	ruff check .
+
+format: ## Auto-fix lint issues with ruff
+	ruff check --fix .
+
+# --- Docker (single container) ----------------------------------------------
+
+docker-build: ## Build the Docker image locally (tppsolver:local)
+	docker build -t tppsolver:local .
+
+docker-run: ## Run the Docker image locally (override with PORT=...)
+	docker run --rm -p $(PORT):8501 tppsolver:local
+
+# --- Docker Compose (deployment) --------------------------------------------
+
+server-compose-build-nocache: ## Compose build with no cache
+	$(COMPOSE) --compatibility build --no-cache
+
+server-compose-interactive: ## Build + up with dev overlay (foreground)
+	$(COMPOSE) --compatibility build
+	$(COMPOSE) --compatibility -f docker-compose.yml -f docker-compose-dev.yml up
+
+server-compose: ## Build + up with dev overlay (detached)
+	$(COMPOSE) --compatibility build
+	$(COMPOSE) --compatibility -f docker-compose.yml -f docker-compose-dev.yml up -d
+
+server-compose-production: ## Build + up production config (detached)
+	$(COMPOSE) --compatibility build
+	$(COMPOSE) --compatibility -f docker-compose.yml up -d
+
+attach: ## Open a shell in the running container
+	docker exec -it tppsolver-streamlit /bin/bash

--- a/README.md
+++ b/README.md
@@ -171,14 +171,20 @@ Explanation of the metadata file columns:
 Dependencies are declared in `pyproject.toml` (the canonical source; `requirements.txt`
 mirrors the core runtime deps for the Docker build).
 
+Common tasks are available via `make` (run `make help` to list them):
+
 ```bash
-# Create an environment and install the app plus dev tools (tests + linter)
+make install   # install the app + dev tools (pytest, ruff) in editable mode
+make run       # launch the Streamlit app (override the port with PORT=8502)
+make test      # run the test suite
+make lint      # lint with ruff
+```
+
+Equivalent raw commands:
+
+```bash
 python -m pip install -e ".[dev]"
-
-# Run the app locally
 streamlit run tpp_solver_mt.py
-
-# Lint and run the test suite
 ruff check .
 pytest
 ```


### PR DESCRIPTION
Adds developer-friendly `make` targets so the app is easy to run:

| Target | Action |
|---|---|
| `make run` | launch the Streamlit app (`PORT=` overridable) |
| `make install` | `pip install -e ".[dev]"` |
| `make test` / `make lint` / `make format` | pytest / ruff / ruff --fix |
| `make docker-build` / `make docker-run` | build & run the image locally |
| `make help` | list all targets (default goal) |

Existing Docker Compose targets are kept (now via a configurable `COMPOSE` var, defaulting to `docker compose` v2) and the `attach` target's container name is corrected to `tppsolver-streamlit`. README updated to point at `make help`.

Verified: `make help`, `make test` (24 pass) and `make lint` (clean) all work.
