### PR TITLE
Fix 'Load example data' (path regression from refactor)

### DIFF
--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,0 +1,25 @@
+"""Guards that bundled data files resolve from the project root.
+
+This is a regression test for the example-data loader, which broke when the
+code moved into the package (``__file__`` then pointed at the package dir
+instead of the repo root where the sample files live).
+"""
+import os
+
+import tpp_solver
+from tpp_solver.io_utils import read_csv_file, read_tsv_file
+
+
+def test_project_root_contains_bundled_data():
+    root = tpp_solver.PROJECT_ROOT
+    assert os.path.isfile(os.path.join(root, "sample_data.tsv"))
+    assert os.path.isfile(os.path.join(root, "sample_metadata.csv"))
+
+
+def test_example_data_loads_from_project_root():
+    root = tpp_solver.PROJECT_ROOT
+    tsv = read_tsv_file(os.path.join(root, "sample_data.tsv"))
+    csv = read_csv_file(os.path.join(root, "sample_metadata.csv"))
+    assert len(tsv) > 0
+    assert "Protein ID" in tsv.columns
+    assert {"Temperature", "Treatment", "Samples"}.issubset(set(csv.columns))

--- a/tpp_solver/__init__.py
+++ b/tpp_solver/__init__.py
@@ -1,3 +1,9 @@
 """TPP Solver: Thermal Proteome Profiling analysis package."""
+import os
 
 __version__ = "1.2.0"
+
+# Repository root (one level above this package). Bundled data files such as the
+# GO database and the example TSV/CSV live here, so paths must be resolved
+# relative to this rather than to a module inside the package.
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/tpp_solver/database.py
+++ b/tpp_solver/database.py
@@ -4,12 +4,11 @@ import os
 import duckdb
 import streamlit as st
 
+from . import PROJECT_ROOT
+
 # Path to the bundled GO/proteome database, resolved relative to the project root
 # so the app works regardless of the process working directory.
-DB_PATH = os.path.join(
-    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
-    "multi_proteome_go.duckdb",
-)
+DB_PATH = os.path.join(PROJECT_ROOT, "multi_proteome_go.duckdb")
 
 @st.cache_resource
 def get_db_connection():

--- a/tpp_solver/ui.py
+++ b/tpp_solver/ui.py
@@ -9,6 +9,7 @@ import matplotlib.pyplot as plt
 import pandas as pd
 import streamlit as st
 
+from . import PROJECT_ROOT
 from .annotation import add_go_annotations, annotate_proteins
 from .database import get_species_list
 from .fitting import fit_and_plot_averaged_curves, fit_and_plot_replicates
@@ -184,9 +185,8 @@ def handle_example_data():
     sample_help = "By pressing this button, sample experimental data will be loaded for demonstration purposes"
     if st.button('Load example data', help=sample_help):
         try:
-            data_path = os.path.dirname(os.path.abspath(__file__))
-            tsv_path = os.path.join(data_path, "sample_data.tsv")
-            csv_path = os.path.join(data_path, "sample_metadata.csv")
+            tsv_path = os.path.join(PROJECT_ROOT, "sample_data.tsv")
+            csv_path = os.path.join(PROJECT_ROOT, "sample_metadata.csv")
             
             if not os.path.exists(tsv_path) or not os.path.exists(csv_path):
                 st.error("Sample data files not found!")


### PR DESCRIPTION
**Bug:** "Load example data" failed with *"Sample data files not found!"*.

**Cause:** `handle_example_data` resolved `sample_data.tsv` / `sample_metadata.csv` relative to `__file__`. After the package refactor (#12), `__file__` points at `tpp_solver/` (the package dir), but the sample files live at the **repo root** one level up. (The DB path had the same hazard and was already handled; this loader was missed.)

**Fix:** introduce a single `PROJECT_ROOT` in `tpp_solver/__init__.py` and use it for both the example-data paths and `DB_PATH`, removing the duplicated path math so this class of bug can't recur in one place but not another.

**Verification:** the exact path logic now resolves (`PROJECT_ROOT` = repo root; both files exist and load — 1008 TSV rows / 40 CSV rows). Added `tests/test_paths.py` (2 regression tests). Full suite: 26 passing, ruff clean.
