### PR TITLE
Speed benchmarks for compute hot-paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,9 @@ run: ## Run the Streamlit app locally (override with PORT=...)
 test: ## Run the test suite
 	$(PYTHON) -m pytest
 
+bench: ## Run speed benchmarks (baselines for the planned Rust rewrite)
+	$(PYTHON) -m pytest benchmarks/ --benchmark-only --benchmark-columns=min,mean,max,rounds
+
 lint: ## Lint with ruff
 	ruff check .
 

--- a/README.md
+++ b/README.md
@@ -197,6 +197,31 @@ Optional extras:
 Continuous integration (`.github/workflows/ci.yml`) runs `ruff` and `pytest`
 against Python 3.10–3.12 on every push and pull request.
 
+### Benchmarks
+
+Speed baselines for the compute hot-paths, to guide a planned Rust rewrite of
+the internals. Benchmarks live in `benchmarks/` and are **excluded from the normal
+test run** (`pytest` only collects `tests/`).
+
+```bash
+pip install -e ".[bench]"
+make bench                      # or: pytest benchmarks/ --benchmark-only
+```
+
+On the bundled ~1000-protein sample dataset, the **sigmoid fitting loop dominates
+by orders of magnitude** (≈2.8 s vs. milliseconds for everything else), so it is
+the prime rewrite target, followed distantly by the data reshape
+(`get_replicate_data`). Numbers are machine-dependent.
+
+To measure a rewrite, save a baseline, change the implementation, then compare:
+
+```bash
+pytest benchmarks/ --benchmark-only --benchmark-save=python
+# ... swap in the Rust implementation ...
+pytest benchmarks/ --benchmark-only --benchmark-compare=python \
+    --benchmark-compare-fail=mean:5%
+```
+
 ### Releasing
 
 Versioning is unified around a single source of truth — `__version__` in

--- a/benchmarks/conftest.py
+++ b/benchmarks/conftest.py
@@ -1,0 +1,36 @@
+"""Shared fixtures for the benchmark suite (loads + preps the sample data once)."""
+import os
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import tpp_solver
+from tpp_solver import preprocessing as P
+
+ROOT = tpp_solver.PROJECT_ROOT
+
+
+@pytest.fixture(scope="session")
+def data():
+    """Realistic inputs derived from the bundled sample dataset (~1000 proteins)."""
+    tsv = pd.read_csv(os.path.join(ROOT, "sample_data.tsv"), sep="\t")
+    meta = pd.read_csv(os.path.join(ROOT, "sample_metadata.csv"))[
+        ["Temperature", "Treatment", "Samples"]
+    ].dropna(subset=["Samples", "Treatment", "Temperature"])
+    samples = meta["Samples"].tolist()
+    filtered, lowest = P.filter_and_lowest_float(tsv, samples)
+    imputed = P.impute_filtered_data(filtered.copy(), samples, lowest, seed=42)
+    rd = P.get_replicate_data(meta, imputed)
+    ref = float(np.min(pd.to_numeric(meta["Temperature"])))
+    return {
+        "tsv": tsv,
+        "meta": meta,
+        "samples": samples,
+        "filtered": filtered,
+        "lowest": lowest,
+        "imputed": imputed,
+        "rd": rd,
+        "ref": ref,
+        "n_proteins": len(tsv),
+    }

--- a/benchmarks/test_bench_pipeline.py
+++ b/benchmarks/test_bench_pipeline.py
@@ -1,0 +1,80 @@
+"""Speed benchmarks for the compute hot-paths.
+
+These establish baselines for the planned Rust rewrite. The prime Rust targets
+are the sigmoid fitting loop (``test_bench_fit_all_proteins``) and the data
+reshape (``test_bench_get_replicate_data``).
+
+Run with:  pytest benchmarks/ --benchmark-only
+Excluded from the normal test run (pyproject ``testpaths = ["tests"]``).
+"""
+import numpy as np
+from scipy.optimize import curve_fit
+
+from tpp_solver import preprocessing as P
+from tpp_solver.models import sigmoid
+from tpp_solver.statistics import benjamini_hochberg
+
+
+def _fit_all(rd, ref):
+    """Pure sigmoid-fit hot loop (no plotting) — mirrors the worker's core math.
+
+    This is the prime Rust-rewrite target: per protein/replicate, normalize to
+    the reference temperature, fit the sigmoid, and compute Tm + R2.
+    """
+    out = []
+    for treatment, proteins in rd.items():
+        for protein, td in proteins.items():
+            temps = np.array(sorted(td.keys()))
+            if len(temps) < 4:
+                continue
+            nrep = min(len(td[t]) for t in temps)
+            ref_idx = np.where(temps == ref)[0]
+            for r in range(nrep):
+                vals = np.array([td[t][r] for t in temps], float)
+                if ref_idx.size and vals[ref_idx[0]] != 0:
+                    vals = vals / vals[ref_idx[0]]
+                try:
+                    popt, _ = curve_fit(
+                        sigmoid, temps, vals,
+                        p0=[vals.max(), float(np.median(temps)), vals.min()], maxfev=10000,
+                    )
+                except Exception:
+                    continue
+                fitted = sigmoid(temps, *popt)
+                ss_res = float(np.sum((vals - fitted) ** 2))
+                ss_tot = float(np.sum((vals - vals.mean()) ** 2))
+                r2 = 1 - ss_res / ss_tot if ss_tot > 0 else 0.0
+                out.append((protein, treatment, r, float(popt[1]), r2))
+    return out
+
+
+def test_bench_fit_all_proteins(benchmark, data):
+    """Sigmoid curve fitting across all proteins/replicates. PRIME Rust target."""
+    result = benchmark(_fit_all, data["rd"], data["ref"])
+    assert len(result) > 0
+
+
+def test_bench_get_replicate_data(benchmark, data):
+    """Reshape the intensity matrix into the nested replicate dict. Rust target."""
+    result = benchmark(P.get_replicate_data, data["meta"], data["imputed"])
+    assert result
+
+
+def test_bench_impute(benchmark, data):
+    """Impute missing values across the intensity matrix."""
+    benchmark(
+        lambda: P.impute_filtered_data(
+            data["filtered"].copy(), data["samples"], data["lowest"], seed=42
+        )
+    )
+
+
+def test_bench_filter_and_lowest_float(benchmark, data):
+    """Coerce + scan the intensity matrix for the lowest non-zero value."""
+    benchmark(P.filter_and_lowest_float, data["tsv"], data["samples"])
+
+
+def test_bench_benjamini_hochberg(benchmark):
+    """FDR correction over a vector of p-values."""
+    pvals = np.random.default_rng(0).uniform(0, 1, size=2000)
+    benchmark(benjamini_hochberg, pvals)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,11 @@ dev = [
     "pytest>=8,<10",
     "ruff>=0.6",
 ]
+# Speed benchmarks (baselines for the planned Rust rewrite).
+bench = [
+    "pytest>=8,<10",
+    "pytest-benchmark>=4",
+]
 
 [tool.setuptools.dynamic]
 version = { attr = "tpp_solver.__version__" }


### PR DESCRIPTION
Adds a benchmark suite to establish performance baselines ahead of the planned Rust rewrite.

## What
- `benchmarks/` with `pytest-benchmark` cases for the compute hot-paths, run on the bundled ~1000-protein sample dataset.
- **Excluded from the normal test run** (`pytest` only collects `tests/` via `testpaths`); run via `make bench` or `pytest benchmarks/ --benchmark-only`.
- New `bench` optional-dependency extra, a `make bench` target, and a README "Benchmarks" section documenting the save → rewrite → compare workflow.

## Baseline (mean, this machine)
| Benchmark | Mean |
|---|---|
| `benjamini_hochberg` | 0.23 ms |
| `filter_and_lowest_float` | 0.94 ms |
| `impute_filtered_data` | 3.97 ms |
| `get_replicate_data` (reshape) | 37.8 ms |
| **`fit_all_proteins` (sigmoid fitting)** | **2,778 ms** |

## Takeaway
The **sigmoid fitting loop dominates by ~4 orders of magnitude** (~2.8 s vs. milliseconds), so it's the clear #1 Rust target (~4,000 `curve_fit` calls). The reshape is a distant second; everything else is negligible.

To measure a rewrite: `--benchmark-save=python`, swap in Rust, `--benchmark-compare=python`.