### PR TITLE
Scaffold for optional native (Rust) fit extension

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ APP     := tpp_solver_mt.py
 
 .DEFAULT_GOAL := help
 
-.PHONY: help install run test lint format docker-build docker-run \
+.PHONY: help install run test bench lint format rust docker-build docker-run \
         server-compose-build-nocache server-compose-interactive \
         server-compose server-compose-production attach
 
@@ -28,6 +28,9 @@ test: ## Run the test suite
 
 bench: ## Run speed benchmarks (baselines for the planned Rust rewrite)
 	$(PYTHON) -m pytest benchmarks/ --benchmark-only --benchmark-columns=min,mean,max,rounds
+
+rust: ## Build the optional native fit extension (rust/) into the venv (needs maturin)
+	cd rust && maturin develop --release
 
 lint: ## Lint with ruff
 	ruff check .

--- a/rust/.gitignore
+++ b/rust/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,0 +1,20 @@
+# Package config only — no implementation. Adjust crate versions to the latest
+# compatible set when you start; pyo3 and numpy majors must match each other.
+[package]
+name = "tpp_fit"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+name = "tpp_fit"
+crate-type = ["cdylib"]   # builds a Python extension module
+
+[dependencies]
+pyo3 = { version = "*", features = ["extension-module"] }
+numpy = "*"                # keep major in lockstep with pyo3
+levenberg-marquardt = "*"  # LM solver; use ITS re-exported nalgebra (see README)
+rayon = "*"                # parallel fitting across curves
+
+[profile.release]
+lto = true
+codegen-units = 1

--- a/rust/README.md
+++ b/rust/README.md
@@ -1,0 +1,113 @@
+# tpp_fit — native fit acceleration (scaffold)
+
+Optional Rust extension that replaces the per-curve sigmoid fitting hot-path
+(the prime target identified by `benchmarks/`). **This is a scaffold only** — the
+Rust implementation lives in `src/lib.rs`, which is intentionally an empty stub.
+
+## Layout
+
+```
+rust/
+├── Cargo.toml        # crate + dependency declarations (config)
+├── pyproject.toml    # maturin build backend
+├── .gitignore        # /target, Cargo.lock
+└── src/
+    └── lib.rs        # <- YOU implement this (currently a commented contract)
+```
+
+## The contract
+
+Expose a single Python function that is a drop-in replacement for the Python
+fitting loop. It must produce the **same numbers** as the reference below.
+
+| | |
+|---|---|
+| Function | `fit_sigmoid_batch(temps, values)` |
+| `temps` | list of 1-D `float64` arrays (one per curve) |
+| `values` | list of 1-D `float64` arrays (same lengths/order) |
+| Returns | list of `Optional[(a, tm, plateau, r2)]`, one per curve, in order |
+| Model | `y = a / (1 + exp(-(T - b))) + plateau`  (`b` = Tm) |
+| Initial guess `p0` | `[max(values), median(temps), min(values)]` |
+| Skip | `< 4` points → `None` |
+| Failure | non-convergence / solver error → `None` |
+| R² | `1 - ss_res/ss_tot`; `ss_tot == 0` → `0.0` |
+
+### Reference implementation (the spec to match — Python)
+
+The Rust output must agree with this within tolerance (Tm `< 1e-2`, R² `< 1e-3`):
+
+```python
+from scipy.optimize import curve_fit
+from tpp_solver.models import sigmoid
+import numpy as np
+
+def fit_sigmoid(temperatures, values):
+    if len(temperatures) < 4:
+        return None
+    try:
+        popt, _ = curve_fit(
+            sigmoid, temperatures, values,
+            p0=[values.max(), np.median(temperatures), values.min()], maxfev=10000,
+        )
+    except Exception:
+        return None
+    fitted = sigmoid(temperatures, *popt)
+    ss_res = float(np.sum((values - fitted) ** 2))
+    ss_tot = float(np.sum((values - values.mean()) ** 2))
+    r2 = 1 - ss_res / ss_tot if ss_tot > 0 else 0.0
+    return float(popt[0]), float(popt[1]), float(popt[2]), r2
+```
+
+## Build
+
+```bash
+pip install maturin
+cd rust
+maturin develop --release        # builds + installs `tpp_fit` into the active venv
+#   or, from repo root:  make rust
+```
+
+## Integrating into the app
+
+Wire it behind an optional import so the app keeps working without the extension:
+
+```python
+# tpp_solver/_fit.py
+try:
+    from tpp_fit import fit_sigmoid_batch as _fit_batch   # native
+    FIT_BACKEND = "rust"
+except ImportError:
+    FIT_BACKEND = "python"
+    def _fit_batch(temps_list, values_list):
+        return [fit_sigmoid(t, v) for t, v in zip(temps_list, values_list)]
+```
+
+The caller collects every replicate's `(temps, values)`, calls `_fit_batch` once,
+then builds the summary/plots — which also lets the worker drop `multiprocessing`
+(parallelism moves into the Rust call).
+
+## Verify
+
+- **Correctness:** add `tests/test_fit_equivalence.py` that runs both backends on
+  the sample data and asserts agreement within the tolerances above. Use
+  `pytest.importorskip("tpp_fit")` so it skips when the extension isn't built.
+- **Speed:** point `benchmarks/test_bench_fit_all_proteins` at `fit_sigmoid_batch`
+  and `--benchmark-compare` against the saved Python baseline.
+
+## Gotchas
+
+1. **nalgebra version** — use the one re-exported by `levenberg-marquardt`
+   (`levenberg_marquardt::nalgebra`); a second, mismatched `nalgebra` dependency
+   causes opaque trait-bound errors.
+2. **Contiguity/dtype** — slicing a numpy array as `&[f64]` requires it to be
+   contiguous `float64`; force `np.ascontiguousarray(x, dtype=np.float64)` before
+   the call.
+3. **GIL** — copy numpy data into owned `Vec`s *before* releasing the GIL
+   (`py.allow_threads`); you can't touch Python objects inside the parallel region.
+
+## Notes
+
+- Expect a solid multiple, not orders of magnitude: each curve is only 8 points,
+  so the win is removing per-fit Python overhead + lighter parallelism (rayon
+  threads vs. Python processes + figure pickling), not faster linear algebra.
+- This crate is not part of the app's CI build; it's an optional accelerator.

--- a/rust/pyproject.toml
+++ b/rust/pyproject.toml
@@ -1,0 +1,12 @@
+# maturin build backend for the native extension. Builds an importable
+# module named `tpp_fit` (matches [lib].name in Cargo.toml).
+[build-system]
+requires = ["maturin>=1.5,<2"]
+build-backend = "maturin"
+
+[project]
+name = "tpp-fit"
+requires-python = ">=3.10"
+dynamic = ["version"]   # taken from Cargo.toml
+
+[tool.maturin]

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,0 +1,36 @@
+//! tpp_fit — native sigmoid curve fitting for TPP melting curves.
+//!
+//! THIS FILE IS AN INTENTIONALLY EMPTY STUB. Implement the crate here.
+//! It contains no code on purpose — only the contract you must satisfy so the
+//! Rust path is a drop-in replacement for the Python fitting loop.
+//!
+//! ── Public surface (the ONE function Python imports) ─────────────────────────
+//!   fit_sigmoid_batch(temps, values) -> list[Optional[(a, tm, plateau, r2)]]
+//!     temps  : list of 1-D float64 arrays (one per curve), contiguous
+//!     values : list of 1-D float64 arrays (same lengths, same order)
+//!     returns: one result per curve, in order; None for skipped/failed fits
+//!
+//! ── Per-curve contract (MUST match tpp_solver._fit.fit_sigmoid exactly) ──────
+//!   model   : y = a / (1 + exp(-(T - b))) + plateau        (b == Tm)
+//!   p0      : [max(values), median(temps), min(values)]
+//!   skip    : fewer than 4 points                 -> None
+//!   fail    : non-convergence / solver error      -> None
+//!   r2      : 1 - ss_res / ss_tot ; if ss_tot == 0 -> 0.0
+//!   return  : (a, tm, plateau, r2)  in THAT order
+//!
+//! ── Suggested structure (see ../README.md for the full plan) ────────────────
+//!   - a struct implementing levenberg_marquardt::LeastSquaresProblem for the
+//!     sigmoid (residuals = model - data; analytic or numerical Jacobian)
+//!   - fn fit_one(t: &[f64], y: &[f64]) -> Option<(f64, f64, f64, f64)>
+//!   - #[pyfunction] fit_sigmoid_batch(...):
+//!       copy numpy -> owned Vec while holding the GIL, then
+//!       py.allow_threads(|| curves.par_iter().map(fit_one).collect())
+//!   - #[pymodule] fn tpp_fit(...) registering fit_sigmoid_batch
+//!
+//! ── Gotchas (see README) ─────────────────────────────────────────────────────
+//!   1. Use the nalgebra re-exported by levenberg-marquardt; never a separate dep.
+//!   2. Force contiguous float64 on the Python side before crossing the boundary.
+//!   3. Copy out of numpy BEFORE allow_threads; no Python objects inside it.
+//!
+//! TODO: write the implementation. (Validate equivalence against scipy on the
+//!       sample data, then benchmark vs the saved Python baseline.)


### PR DESCRIPTION
Adds a **scaffold only** for an optional Rust extension (`tpp_fit`) that would replace the sigmoid fitting hot-path (the ~99.8% of compute the benchmarks flagged). No Rust implementation — that's left to be written by hand.

## What's here
```
rust/
├── Cargo.toml      # crate + dependency declarations (config)
├── pyproject.toml  # maturin build backend
├── .gitignore
└── src/lib.rs      # empty, comment-only stub: states the contract, no code
```
Plus `rust/README.md` documenting: the function contract, the **Python reference implementation to match**, build (`maturin develop` / `make rust`), integration via optional import with a pure-Python fallback, and the equivalence + benchmark checks. A `make rust` target is added.

## Intentionally not included
- Any Rust implementation. `src/lib.rs` contains only a commented contract and TODOs.
- CI build of the crate — it's an optional accelerator; the app runs on the pure-Python path regardless.

## Verification
ruff clean, tests pass (17), `src/lib.rs` is comment-only (no code).